### PR TITLE
[rofi] Change bgcolor of selected item

### DIFF
--- a/rofi/srcery_rofi.rasi
+++ b/rofi/srcery_rofi.rasi
@@ -48,7 +48,7 @@
   highlight:     bold #E02C6D;
 
   selected-normal-foreground:  @black;
-  selected-normal-background:  @white;
+  selected-normal-background:  @brightwhite;
 
   normal-foreground:           @brightwhite;
   normal-background:           @brightblack;


### PR DESCRIPTION
The default background color of the selected item makes the highlighted letters hard to read. This PR just changes the background of the selected item from `white` (fig. 1) to `brightwhite` (fig. 2), so that it is easier to read.

### Fig. 1
![Fig. 1](https://user-images.githubusercontent.com/14995334/44999699-9ba9a200-afbf-11e8-8af2-a06340868946.png)

### Fig. 2
![Fig. 2](https://user-images.githubusercontent.com/14995334/44999703-a06e5600-afbf-11e8-8d56-7351ee072c25.png)
